### PR TITLE
set the default rank prev and next value if it is empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/danghh-1998/lexorank
+module github.com/elauven/lexorank
 
 go 1.19

--- a/lexorank.go
+++ b/lexorank.go
@@ -74,6 +74,12 @@ func validateRank(rank string) bool {
 }
 
 func Rank(prev string, next string) (string, error) {
+	if prev == "" {
+		prev = string(MinLexo)
+	}
+	if next == "" {
+		next = string(MaxLexo)
+	}
 	for len(prev) != len(next) {
 		if len(prev) > len(next) {
 			next += string(MinLexo)


### PR DESCRIPTION
To simplify usage, default values have been added for rank prev in MinLexo and next in MaxLexo. Maybe this case is needed only in my case, and you can drop this pr